### PR TITLE
お気に入り完成,テストデータ作成

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,86 @@
+class BookmarksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_bookmark, only: :destroy
+
+  # GET /bookmarks　トグル切り替え
+  def index
+    type = params[:type] || "Vocabulary"
+    @active_tab = type
+
+    case type
+    when "Vocabulary"
+      @bookmarks = current_user.bookmarks.where(bookmarkable_type: "Vocabulary")
+                                         .includes(:bookmarkable)
+                                         .page(params[:page]).per(10)
+    when "Sentence"
+      @bookmarks = current_user.bookmarks.where(bookmarkable_type: "Sentence")
+                                         .includes(:bookmarkable)
+                                         .page(params[:page]).per(10)
+    end
+  end
+
+  # POST /bookmarks
+  def create
+    bookmarkable = find_bookmarkable!
+    bookmark = current_user.bookmarks.find_or_initialize_by(bookmarkable: bookmarkable)
+    @record = bookmarkable
+
+    if bookmark.persisted? || bookmark.save
+      respond_to do |format|
+        format.turbo_stream { render :create }
+        format.html { redirect_back fallback_location: bookmarks_path, notice: t("flash.bookmarks.create.success", default: "お気に入りに追加しました") }
+        format.json { head :ok }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(dom_id(@record, :bookmark_star), partial: "bookmarks/star", locals: { record: @record }) }
+        format.html { redirect_back fallback_location: bookmarks_path, alert: t("flash.bookmarks.create.failure", default: "お気に入りに追加できませんでした") }
+        format.json { render json: { error: "unprocessable" }, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /bookmarks/:id
+  def destroy
+    @record = @bookmark.bookmarkable
+    @bookmark.destroy
+
+    respond_to do |format|
+      format.turbo_stream { render :destroy }
+      format.html { redirect_back fallback_location: bookmarks_path, notice: t("flash.bookmarks.destroy.success", default: "お気に入りを削除しました") }
+      format.json { head :ok }
+    end
+  end
+
+  private
+
+  # 許可するモデルだけを通す（安全な constantize）
+  ALLOWED_TYPES = %w[Vocabulary Sentence].freeze
+
+  def find_bookmarkable!
+    type = params.require(:bookmarkable_type)
+    id   = params.require(:bookmarkable_id)
+    raise ActiveRecord::RecordNotFound unless ALLOWED_TYPES.include?(type)
+    type.constantize.find(id)
+  end
+
+  def set_bookmark
+    @bookmark = current_user.bookmarks.find(params[:id])
+  end
+
+  # Turbo対応の共通レスポンス
+  def respond_ok(notice:)
+    respond_to do |format|
+      format.html { redirect_back fallback_location: bookmarks_path, notice: }
+      format.turbo_stream
+      format.json { head :ok }
+    end
+  end
+
+  def respond_back(alert:)
+    respond_to do |format|
+      format.html { redirect_back fallback_location: bookmarks_path, alert: }
+      format.json { render json: { error: alert }, status: :unprocessable_entity }
+    end
+  end
+end

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,0 +1,35 @@
+module BookmarksHelper
+  def bookmarked?(record)
+    return false unless current_user
+    current_user.bookmarks.exists?(bookmarkable: record)
+  end
+
+  def bookmark_for(record)
+    current_user&.bookmarks&.find_by(bookmarkable: record)
+  end
+
+    # タグ名の配列化（モデル差異を吸収）
+  def tags_for(record)
+    if record.respond_to?(:tags)
+      Array(record.tags).map { |t| t.respond_to?(:name) ? t.name : t.to_s }
+    elsif record.respond_to?(:vocabulary_tags)
+      Array(record.vocabulary_tags).map { |t| t.respond_to?(:name) ? t.name : t.to_s }
+    elsif record.respond_to?(:sentence_tags)
+      Array(record.sentence_tags).map { |t| t.respond_to?(:name) ? t.name : t.to_s }
+    else
+      []
+    end
+  end
+
+  # 品詞 enum を翻訳
+  def translate_part_of_speech(pos_value)
+    return if pos_value.blank?
+    I18n.t("enums.vocabulary.part_of_speech.#{pos_value}", default: pos_value)
+  end
+
+  # 文章種類 enum を翻訳
+  def translate_sentence_category(cat_value)
+    return if cat_value.blank?
+    I18n.t("enums.sentence.sentence_category.#{cat_value}", default: cat_value)
+  end
+end

--- a/app/models/add_indexes_to_bookmark.rb
+++ b/app/models/add_indexes_to_bookmark.rb
@@ -1,0 +1,2 @@
+class AddIndexesToBookmark < ApplicationRecord
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,5 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :bookmarkable, polymorphic: true
+  validates :user_id, uniqueness: { scope: [:bookmarkable_id, :bookmarkable_type] }
+end

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -2,6 +2,7 @@ class Sentence < ApplicationRecord
   belongs_to :user
   has_many :sentence_taggings, dependent: :destroy
   has_many :sentence_tags, through: :sentence_taggings
+  has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   
   enum sentence_category: {
     metaphor: 0,        # 比喩
@@ -11,8 +12,9 @@ class Sentence < ApplicationRecord
     conversation: 4,    # 会話
     expression: 5,      # 表現
     logic: 6,           # 論理
-    gag: 7,             #ギャグ
-    other: 8,           #その他
+    gag: 7,             # ギャグ
+    philosophy: 8,      # 哲学
+    other: 9           # その他
   }
 
   validates :body, presence: true, length: { maximum: 500 }, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,17 @@
 class User < ApplicationRecord
-  # sorceryによる認証機能を追加 → Deviseに移行
-  #authenticates_with_sorcery!
+  #devise
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
+  #語彙、文章
   has_many :vocabularies, dependent: :destroy
   has_many :sentences, dependent: :destroy
+  #タグ
   has_many :sentence_tags, dependent: :destroy
   has_many :vocabulary_tags, dependent: :destroy
+  #bookmark
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_vocabularies, through: :bookmarks, source: :bookmarkable, source_type: "Vocabulary"
+  has_many :bookmark_sentences, through: :bookmarks, source: :bookmarkable, source_type: "Sentence"
   
 
   # 保存前に入力を整形する(前後スペース削除・メールを小文字化)

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -2,7 +2,8 @@ class Vocabulary < ApplicationRecord
   belongs_to :user
   has_many :vocabulary_taggings, dependent: :destroy
   has_many :vocabulary_tags, through: :vocabulary_taggings
-
+  has_many :bookmarks, as: :bookmarkable, dependent: :destroy
+  #品詞タグ
   enum part_of_speech: {
     noun: 0,        # 名詞
     verb: 1,        # 動詞
@@ -20,6 +21,8 @@ class Vocabulary < ApplicationRecord
   validates :word, presence: true, length: { maximum: 100 }, uniqueness: { scope: :user_id }
   validate :limit_vocabulary_tags_count
 
+
+  #ransackアクセス許可
   def self.ransackable_attributes(_auth = nil)
     %w[word reading meaning example part_of_speech created_at updated_at]
   end

--- a/app/views/bookmarks/_star.html.erb
+++ b/app/views/bookmarks/_star.html.erb
@@ -1,0 +1,14 @@
+<span id="<%= dom_id(record, :bookmark_star) %>">
+  <% bookmarked = bookmarked?(record) %>
+  <% bm = bookmark_for(record) %>
+
+  <% if bookmarked %>
+    <%= button_to "⭐️", bookmark_path(bm), method: :delete,
+          class: "text-yellow-400 text-xl",
+          form: { data: { turbo_confirm: t("common.remove") } } %>
+  <% else %>
+    <%= button_to "☆", bookmarks_path(bookmarkable_id: record.id, bookmarkable_type: record.class.name),
+          method: :post,
+          class: "text-gray-400 text-xl" %>
+  <% end %>
+</span>

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@record, :bookmark_star) do %>
+  <%= render "bookmarks/star", record: @record %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@record, :bookmark_star) do %>
+  <%= render "bookmarks/star", record: @record %>
+<% end %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,105 @@
+<div class="max-w-3xl mx-auto">
+  <h1 class="text-xl font-bold mb-4">お気に入り</h1>
+
+  <%# タブ（フレーム内に移動） %>
+
+  <!-- 一覧 -->
+  <%= turbo_frame_tag "bookmarks_list" do %>
+    <!-- タブ（フレーム内に移動） -->
+    <div class="flex mb-4 space-x-4 border-b">
+      <%= link_to t(".vocabulary"),
+          bookmarks_path(type: "Vocabulary"),
+          data: { turbo_frame: "bookmarks_list" },
+          class: "pb-2 #{ @active_tab == "Vocabulary" ? "border-b-2 border-blue-600 font-semibold" : "text-gray-500" }" %>
+      <%= link_to t(".sentence"),
+          bookmarks_path(type: "Sentence"),
+          data: { turbo_frame: "bookmarks_list" },
+          class: "pb-2 #{ @active_tab == "Sentence" ? "border-b-2 border-blue-600 font-semibold" : "text-gray-500" }" %>
+    </div>
+    <% if @bookmarks.blank? %>
+      <p class="text-gray-500"><%= t(".empty") %></p>
+    <% else %>
+      <ul class="space-y-3">
+        <% @bookmarks.each do |bm| %>
+          <li class="rounded-2xl border bg-white p-4 shadow hover:shadow-md transition flex items-start justify-between gap-4">
+            <div class="pr-3 max-w-[85%]">
+              <% if bm.bookmarkable_type == "Vocabulary" %>
+                <%= link_to polymorphic_path(bm.bookmarkable), class: "block" do %>
+                  <div class="font-semibold text-lg inline"><%= truncate(bm.bookmarkable.word.to_s, length: 24, omission: "…") %></div>
+                  <span class="text-sm text-gray-500 ml-1">
+                    <%= truncate((bm.bookmarkable.reading.presence || t("vocabularies.index.reading_none")).to_s, length: 48, omission: "…") %>
+                    /
+                    <%= t("enums.vocabulary.part_of_speech.#{bm.bookmarkable.part_of_speech}") %>
+                  </span>
+
+                  <div class="mt-2 pl-3 border-l-4 border-blue-300">
+                    <div class="text-[11px] font-semibold text-blue-700 tracking-wide uppercase"><%= t("vocabularies.index.mean_label") %></div>
+                    <div class="mt-1 text-sm text-gray-800 leading-relaxed break-words">
+                      <%= clamp_lines(bm.bookmarkable.meaning, max_lines: 3) %>
+                    </div>
+                  </div>
+
+                  <% if bm.bookmarkable.example.present? %>
+                    <div class="mt-2 pl-3 border-l-4 border-green-300">
+                      <div class="text-[11px] font-semibold text-green-700 tracking-wide uppercase"><%= t("vocabularies.index.example_label") %></div>
+                      <div class="mt-1 text-xs text-gray-600 leading-relaxed break-words">
+                        <%= clamp_lines(bm.bookmarkable.example, max_lines: 3) %>
+                      </div>
+                    </div>
+                  <% end %>
+                <% end %>
+
+                <%# タグ（語彙）: 一覧と同じ色付きチップ＋リンク %>
+                <% if bm.bookmarkable.respond_to?(:vocabulary_tags) && bm.bookmarkable.vocabulary_tags.any? %>
+                  <div class="relative z-50 pointer-events-auto mt-2 flex flex-wrap gap-2 max-h-16 overflow-y-auto">
+                    <% bm.bookmarkable.vocabulary_tags.order(:name).each do |tag| %>
+                      <%= link_to tag.name,
+                          vocabularies_path(q: { vocabulary_tags_id_in: [tag.id] }),
+                          class: "px-2 py-1 rounded-full border text-xs hover:opacity-80",
+                          style: "background-color: #{tag.color.presence || '#000'}; color: #fff;" %>
+                    <% end %>
+                  </div>
+                <% end %>
+
+              <% else %>
+                <%= link_to polymorphic_path(bm.bookmarkable), class: "block" do %>
+                  <div class="text-sm text-gray-500 mb-1"><%= t("bookmarks.index.sentence") %></div>
+                  <div class="text-base font-semibold leading-snug"><%= clamp_lines(bm.bookmarkable.body, max_lines: 3) %></div>
+                <% end %>
+
+                <%# 種類（文章） %>
+                <% raw_cat = bm.bookmarkable.try(:sentence_category) %>
+                <% if raw_cat.present? %>
+                  <div class="mt-2 text-xs text-gray-600">
+                    <span class="mr-2"><%= t("bookmarks.index.sentence_category") %>:</span>
+                    <span class="inline-block rounded border px-2 py-0.5 bg-gray-50"><%= t("enums.sentence.sentence_category.#{raw_cat}", default: raw_cat) %></span>
+                  </div>
+                <% end %>
+
+                <%# タグ（文章）: 色付きチップ＋リンク（文章一覧のフィルタへ） %>
+                <% if bm.bookmarkable.respond_to?(:sentence_tags) && bm.bookmarkable.sentence_tags.any? %>
+                  <div class="relative z-50 pointer-events-auto mt-2 flex flex-wrap gap-2 max-h-16 overflow-y-auto">
+                    <% bm.bookmarkable.sentence_tags.order(:name).each do |tag| %>
+                      <%= link_to tag.name,
+                          sentences_path(q: { sentence_tags_id_in: [tag.id] }),
+                          class: "px-2 py-1 rounded-full border text-xs hover:opacity-80",
+                          style: "background-color: #{tag.color.presence || '#000'}; color: #fff;" %>
+                    <% end %>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+
+            <div class="shrink-0 pl-3">
+              <%= render "bookmarks/star", record: bm.bookmarkable %>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+
+      <div class="mt-4">
+        <%= paginate @bookmarks %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/sentences/index.html.erb
+++ b/app/views/sentences/index.html.erb
@@ -37,12 +37,15 @@
         </div>
         <%# 作成日を表示 %>
         <div class="text-xs text-gray-500 text-right whitespace-nowrap">
+          <div class="mb-2 relative z-20 pointer-events-auto">
+            <%= render "bookmarks/star", record: v %>
+          </div>
           <div><%= t("common.created_day") %></div>
           <div><%= v.created_at.strftime("%Y/%m/%d %H:%M") %></div><br>
           <div><%= t("common.updated_day") %></div>
           <div><%= v.updated_at.strftime("%Y/%m/%d %H:%M") %></div>
         </div>
-        <%= link_to "", sentence_path(v), class: "absolute inset-0 z-10 block" %>
+        <%= link_to "", sentence_path(v), class: "absolute inset-0 z-0 block" %>
       </div>
     <% end %>
     <%# 登録がない場合 %>

--- a/app/views/sentences/show.html.erb
+++ b/app/views/sentences/show.html.erb
@@ -8,6 +8,8 @@
 
   <%= render "shared/error_messages", object: @sentence %>
 
+  <%= render "bookmarks/star", record: @sentence %>
+
   <%= form_with model: @sentence, url: sentence_path(@sentence), method: :patch, local: true, data: { "edit-toggle-target": "form" } do |f| %>
     <div class="rounded-2xl bg-white text-gray-900 shadow p-6 space-y-4" data-edit-toggle-target="container">
       <div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
       <%= link_to t(".sentence_index"), sentences_path, class: "hover:underline" %>
       <%= link_to t(".vocabulary_index"), vocabularies_path, class: "hover:underline" %>
       <%= link_to t(".tag_edit"), tags_path, class: "hover:underline" %>
-      <%= link_to t(".bookmark"), "#", class: "hover:underline" %>
+      <%= link_to t(".bookmark"), bookmarks_path, class: "hover:underline" %>
     </nav>
     <nav class="flex space-x-4">
       <%= link_to t(".user_show"), edit_user_registration_path, class: "hover:underline" %>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -15,7 +15,10 @@
       <div class="relative p-4 flex items-start justify-between gap-4 hover:bg-gray-200 cursor-pointer">
         <div class="break-words">
           <div class="font-semibold text-lg inline"><%= truncate(v.word.to_s, length: 24, omission: "…") %></div>
-          <span class="text-sm text-gray-500 ml-1"><%= truncate((v.reading.presence || t(".reading_none")).to_s, length: 48, omission: "…") %> / <%= t("enums.vocabulary.part_of_speech.#{v.part_of_speech}") %></span>
+          <span class="text-sm text-gray-500 ml-1">
+            <%= truncate((v.reading.presence || t(".reading_none")).to_s, length: 48, omission: "…") %> /
+            <%= t("enums.vocabulary.part_of_speech.#{v.part_of_speech}") %>
+          </span>
           <div class="mt-2 pl-3 border-l-4 border-blue-300">
             <div class="text-[11px] font-semibold text-blue-700 tracking-wide uppercase"><%= t(".mean_label") %></div>
             <div class="mt-1 text-sm text-gray-800 leading-relaxed break-words">
@@ -44,12 +47,15 @@
         </div>  
         <%# 作成日・更新日を表示 %>
         <div class="text-xs text-gray-500 text-right whitespace-nowrap">
+          <div class="mb-2 relative z-10 pointer-events-auto">
+            <%= render "bookmarks/star", record: v %>
+          </div>
           <div><%= t("common.created_day") %></div>
           <div><%= v.created_at.strftime("%Y/%m/%d %H:%M") %></div><br>
           <div><%= t("common.updated_day") %></div>
           <div><%= v.updated_at.strftime("%Y/%m/%d %H:%M") %></div>
         </div>
-        <%= link_to "", vocabulary_path(v), class: "absolute inset-0", aria: { label: v.word } %>
+        <%= link_to "", vocabulary_path(v), class: "absolute inset-0 z-0", aria: { label: v.word } %>
       </div>
     <% end %>
     <%# 登録がない場合 %>

--- a/app/views/vocabularies/show.html.erb
+++ b/app/views/vocabularies/show.html.erb
@@ -38,8 +38,6 @@
               data: { "edit-toggle-target": "field" }, disabled: true %>
       </div>
 
-      <!-- タグ群は後で実装 -->
-
       <%# タグ表示 %>
       <% if @vocabulary.vocabulary_tags.any? %>
         <div class="mt-3 flex flex-wrap gap-2">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,6 +27,7 @@ ja:
     sort: "並び替え: "
     created_day: "作成日"
     updated_day: "更新日"
+    remove: "解除しますか？"
   passwords:
     edit:
       title: "新しいパスワードを設定"
@@ -142,7 +143,8 @@ ja:
         conversation: "会話"   
         expression: "表現"     
         logic: "論理"          
-        gag: "ギャグ"            
+        gag: "ギャグ"
+        philosophy: "哲学"            
         other: "その他"          
   tags:
     index:
@@ -205,6 +207,27 @@ ja:
       title: "語彙タグ新規作成"
       tag_name: "タグ名"
       return_vocabulary_tag_index: "語彙タグ一覧へ戻る"
+  bookmarks:
+    index:
+      title: "お気に入り"
+      empty: "まだ登録がありません"
+      vocabulary: "語彙"
+      sentence: "文章"
+      tags: "タグ"
+      part_of_speech: "品詞"
+      sentence_category: "種類"
+    button:
+      add: "お気に入りに追加"
+      remove: "お気に入り解除"
+    confirm:
+      remove: "解除しますか？"
+  flash:
+    bookmarks:
+      create:
+        success: "お気に入りに追加しました"
+        failure: "お気に入りに追加できませんでした"
+      destroy:
+        success: "お気に入りを削除しました"    
 
   devise:
     shared:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
   # 文章タグ/語彙タグ
   resources :sentence_tags, only: %i[index new create update destroy]
   resources :vocabulary_tags, only: %i[index new create update destroy]
+  # bookmark
+  resources :bookmarks, only: [:index, :create, :destroy]
   # カレンダーに日毎の登録数を表示するダッシュボード
   resource :dashboard, only: [ :show ]
   # letter_opener

--- a/db/demo_sentences.yml
+++ b/db/demo_sentences.yml
@@ -1,0 +1,139 @@
+tags:
+  - name: "ワンピース"
+  - name: "ゴールド・ロジャー"
+  - name: "ルフィ"
+  - name: "ゾロ"
+  - name: "ドラゴンボール"
+  - name: "孫悟空"
+  - name: "ナルト"
+  - name: "うずまきナルト"
+  - name: "BLEACH"
+  - name: "黒崎一護"
+  - name: "進撃の巨人"
+  - name: "リヴァイ"
+  - name: "エレン"
+  - name: "エヴァンゲリオン"
+  - name: "碇シンジ"
+  - name: "渚カヲル"
+  - name: "グレンラガン"
+  - name: "シモン"
+  - name: "銀魂"
+  - name: "坂田銀時"
+  - name: "コードギアス"
+  - name: "ルルーシュ"
+  - name: "シュタインズ・ゲート"
+  - name: "岡部倫太郎"
+  - name: "リゼロ"
+  - name: "スバル"
+  - name: "ジョジョ"
+  - name: "ディオ"
+  - name: "夏目漱石"
+  - name: "こころ"
+  - name: "草枕"
+  - name: "太宰治"
+  - name: "人間失格"
+  - name: "芥川龍之介"
+  - name: "羅生門"
+  - name: "宮沢賢治"
+  - name: "銀河鉄道の夜"
+
+sentences:
+  - body: "探せ！この世の全てをそこに置いてきた！"
+    sentence_category: "conversation"
+    sentence_tags: ["ワンピース","ゴールド・ロジャー"]
+
+  - body: "海賊王に!!! 俺はなるっ!!!"
+    sentence_category: "conversation"
+    sentence_tags: ["ワンピース","ルフィ"]
+
+  - body: "背中の傷は剣士の恥だ。"
+    sentence_category: "logic"
+    sentence_tags: ["ワンピース","ゾロ"]
+
+  - body: "オラわくわくすっぞ！"
+    sentence_category: "expression"
+    sentence_tags: ["ドラゴンボール","孫悟空"]
+
+  - body: "俺は火影になるってばよ！誰にも笑わせやしねぇ！"
+    sentence_category: "conversation"
+    sentence_tags: ["ナルト","うずまきナルト"]
+
+  - body: "護るためだろ？護りたいものがあるから俺は斬るんだ！"
+    sentence_category: "logic"
+    sentence_tags: ["BLEACH","黒崎一護"]
+
+  - body: "俺が仕留める。お前らは心臓を捧げろ。"
+    sentence_category: "logic"
+    sentence_tags: ["進撃の巨人","リヴァイ"]
+
+  - body: "駆逐してやる！この世から一匹残らず！"
+    sentence_category: "expression"
+    sentence_tags: ["進撃の巨人","エレン"]
+
+  - body: "逃げちゃダメだ、逃げちゃダメだ、逃げちゃダメだ！"
+    sentence_category: "psychology"
+    sentence_tags: ["エヴァンゲリオン","碇シンジ"]
+
+  - body: "君は死ぬために生きているわけじゃない。生きるために生きるんだよ。"
+    sentence_category: "psychology"
+    sentence_tags: ["エヴァンゲリオン","渚カヲル"]
+
+  - body: "俺を誰だと思ってやがる！天を突くドリル、グレン団のシモン様だ！"
+    sentence_category: "expression"
+    sentence_tags: ["グレンラガン","シモン"]
+
+  - body: "俺の後ろに立つな。"
+    sentence_category: "conversation"
+    sentence_tags: ["銀魂","坂田銀時"]
+
+  - body: "撃っていいのは、撃たれる覚悟のある奴だけだ。"
+    sentence_category: "logic"
+    sentence_tags: ["コードギアス","ルルーシュ"]
+
+  - body: "この世界は選ばれし観測者によって収束する！我が名は鳳凰院凶真！"
+    sentence_category: "expression"
+    sentence_tags: ["シュタインズ・ゲート","岡部倫太郎"]
+
+  - body: "俺が必ずお前を救ってみせる！何度でもやり直して！"
+    sentence_category: "expression"
+    sentence_tags: ["リゼロ","スバル"]
+
+  - body: "無駄無駄無駄無駄ァ！！"
+    sentence_category: "expression"
+    sentence_tags: ["ジョジョ","ディオ"]
+
+  - body: "私はその人を常に先生と呼んでいた。"
+    sentence_category: "description"
+    sentence_tags: ["夏目漱石","こころ"]
+
+  - body: "山路を登りながら、こう考えた。智に働けば角が立つ。情に棹させば流される。"
+    sentence_category: "psychology"
+    sentence_tags: ["夏目漱石","草枕"]
+
+  - body: "恥の多い生涯を送ってきました。"
+    sentence_category: "psychology"
+    sentence_tags: ["太宰治","人間失格"]
+
+  - body: "生まれて、すみません。"
+    sentence_category: "psychology"
+    sentence_tags: ["太宰治","人間失格"]
+
+  - body: "ある日の暮れ方の事である。一人の下人が、羅生門の下で雨やみを待っていた。"
+    sentence_category: "description"
+    sentence_tags: ["芥川龍之介","羅生門"]
+
+  - body: "あの大きな時計の針が、二人の時間を刻んでいるように思えた。"
+    sentence_category: "appearance"
+    sentence_tags: ["文学","情景"]
+
+  - body: "誰がために鐘は鳴るか。鐘は汝のために鳴る。"
+    sentence_category: "psychology"
+    sentence_tags: ["文学","宗教"]
+
+  - body: "星めぐりの歌をうたいながら、ジョバンニとカムパネルラは銀河鉄道に乗った。"
+    sentence_category: "description"
+    sentence_tags: ["宮沢賢治","銀河鉄道の夜"]
+
+  - body: "おまえはもう死んでいる。"
+    sentence_category: "conversation"
+    sentence_tags: ["北斗の拳","ケンシロウ"]

--- a/db/demo_vocabularies.yml
+++ b/db/demo_vocabularies.yml
@@ -1,0 +1,190 @@
+tags:
+  - name: "故事成語"
+  - name: "夏目漱石"
+  - name: "坊ちゃん"
+  - name: "中国"
+  - name: "仏教"
+  - name: "神"
+  - name: "ファンタジー"
+  - name: "軍事"
+  - name: "宗教"
+  - name: "日常"
+  - name: "心理"
+  - name: "情景"
+
+vocabularies:
+  - word: "灼熱"
+    reading: "しゃくねつ"
+    part_of_speech: "noun"
+    meaning: "焼けつくように熱いこと"
+    example: "灼熱の午後だった。"
+    vocabulary_tags: ["情景"]
+
+  - word: "瞬発"
+    reading: "しゅんぱつ"
+    part_of_speech: "noun"
+    meaning: "瞬間的に発動する力"
+    example: "瞬発力が勝負を決める。"
+    vocabulary_tags: ["日常"]
+
+  - word: "円転滑脱"
+    reading: "えんてんかつだつ"
+    part_of_speech: "idiom"
+    meaning: "滞りなく自由自在であること"
+    example: "彼は円転滑脱に自身の仕事を全うした。"
+    vocabulary_tags: ["故事成語"]
+
+  - word: "とっくりと"
+    reading: ""
+    part_of_speech: "adverb"
+    meaning: "念を込めて物事を丁寧に行う様子"
+    example: "彼はとっくりと陛下に頭を垂れた。"
+    vocabulary_tags: ["日常"]
+
+  - word: "油を売る"
+    reading: "あぶらをうる"
+    part_of_speech: "phrase"
+    meaning: "仕事をサボって、話し込んでいるさま"
+    example: "お客と話し込んでいたら、上司に油を売るなと怒られてしまった。"
+    vocabulary_tags: ["日常"]
+
+  - word: "塞翁が馬"
+    reading: "さいおうがうま"
+    part_of_speech: "phrase"
+    meaning: "人生の禍福は転々として予測できないこと"
+    example: "人生塞翁が馬。何が起こるかなんてわからないものさ。"
+    vocabulary_tags: ["故事成語","中国"]
+
+  - word: "無鉄砲"
+    reading: "むてっぽう"
+    part_of_speech: "adjective"
+    meaning: "是非や結果を考えずにむやみに行動すること。そのさまや、そのような人。"
+    example: "彼は昔から無鉄砲な性格で、まわりをかえりみなかった。"
+    vocabulary_tags: ["夏目漱石","坊ちゃん"]
+
+  - word: "韋駄天"
+    reading: "いだてん"
+    part_of_speech: "noun"
+    meaning: |
+      ①早く走ること、またはその人自身を指す。
+      ②増長天の八代将軍の一。仏法の守護神
+    example: "韋駄天の如く疾走した。"
+    vocabulary_tags: ["仏教","神"]
+
+  - word: "要衝"
+    reading: "ようしょう"
+    part_of_speech: "noun"
+    meaning: "軍事・交通・産業のうえで大切な地点、要所。"
+    example: "この地は我が軍にとって重要な要衝のひとつだ。"
+    vocabulary_tags: ["ファンタジー","軍事"]
+
+  - word: "猊下"
+    reading: "げいか"
+    part_of_speech: "noun"
+    meaning: |
+      ①一つの宗派の管長に対する敬称
+      ②高僧に対する敬称
+      ③高僧のそば
+      ④僧に送る書面の脇付けに用いる語
+    example: "猊下はこの宗派の頂点であり象徴だ。"
+    vocabulary_tags: ["ファンタジー","宗教"]
+
+  # ---- ここから日常的な追加 ----
+  - word: "快晴"
+    reading: "かいせい"
+    part_of_speech: "noun"
+    meaning: "雲ひとつない晴れ渡った空模様。"
+    example: "今日は快晴で気持ちがいい。"
+    vocabulary_tags: ["日常","情景"]
+
+  - word: "微睡む"
+    reading: "まどろむ"
+    part_of_speech: "verb"
+    meaning: "うとうとと眠る。浅い眠りにつく。"
+    example: "午後の光の中で微睡んでいた。"
+    vocabulary_tags: ["日常"]
+
+  - word: "煌めき"
+    reading: "きらめき"
+    part_of_speech: "noun"
+    meaning: "光が瞬くように輝くこと。"
+    example: "波間に星の煌めきが映る。"
+    vocabulary_tags: ["情景"]
+
+  - word: "独白"
+    reading: "どくはく"
+    part_of_speech: "noun"
+    meaning: "一人で声に出して言うこと。心の内を語ること。"
+    example: "舞台で彼は長い独白をした。"
+    vocabulary_tags: ["文学","心理"]
+
+  - word: "憧憬"
+    reading: "しょうけい"
+    part_of_speech: "noun"
+    meaning: "あこがれること。強い思いを寄せること。"
+    example: "彼の瞳は未来への憧憬に満ちていた。"
+    vocabulary_tags: ["心理"]
+
+  - word: "慈悲"
+    reading: "じひ"
+    part_of_speech: "noun"
+    meaning: "人を憐れみ、苦しみを救おうとする心。"
+    example: "僧は慈悲の心で人々を導いた。"
+    vocabulary_tags: ["宗教"]
+
+  - word: "灯火"
+    reading: "ともしび"
+    part_of_speech: "noun"
+    meaning: "灯されたあかり。光明。"
+    example: "暗闇に小さな灯火が揺れる。"
+    vocabulary_tags: ["情景"]
+
+  - word: "風花"
+    reading: "かざはな"
+    part_of_speech: "noun"
+    meaning: "晴れているのに雪が舞う現象。"
+    example: "冬空に風花が舞っていた。"
+    vocabulary_tags: ["情景"]
+
+  - word: "無常"
+    reading: "むじょう"
+    part_of_speech: "noun"
+    meaning: "この世のものは常に変化し、永続しないこと。"
+    example: "人生の無常を感じる。"
+    vocabulary_tags: ["文学","宗教"]
+
+  - word: "悠然"
+    reading: "ゆうぜん"
+    part_of_speech: "adverb"
+    meaning: "落ち着いてゆったりとした様子。"
+    example: "彼は悠然と歩いていた。"
+    vocabulary_tags: ["日常"]
+
+  - word: "驟雨"
+    reading: "しゅうう"
+    part_of_speech: "noun"
+    meaning: "急に降ってすぐにやむ雨。にわか雨。"
+    example: "夏の午後、驟雨に見舞われた。"
+    vocabulary_tags: ["情景"]
+
+  - word: "脈動"
+    reading: "みゃくどう"
+    part_of_speech: "noun"
+    meaning: "脈を打つこと。規則正しい動き。"
+    example: "大地の脈動を感じる。"
+    vocabulary_tags: ["心理"]
+
+  - word: "輪廻"
+    reading: "りんね"
+    part_of_speech: "noun"
+    meaning: "生死を繰り返すこと。仏教思想の一つ。"
+    example: "魂は輪廻を繰り返す。"
+    vocabulary_tags: ["宗教"]
+
+  - word: "萌芽"
+    reading: "ほうが"
+    part_of_speech: "noun"
+    meaning: "芽が出はじめること。物事の始まり。"
+    example: "新しい思想の萌芽。"
+    vocabulary_tags: ["日常"]
+    

--- a/db/migrate/20250918000306_create_bookmarks.rb
+++ b/db/migrate/20250918000306_create_bookmarks.rb
@@ -1,0 +1,10 @@
+class CreateBookmarks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :bookmarkable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250918001222_create_add_indexes_to_bookmarks.rb
+++ b/db/migrate/20250918001222_create_add_indexes_to_bookmarks.rb
@@ -1,0 +1,8 @@
+class CreateAddIndexesToBookmarks < ActiveRecord::Migration[7.2]
+  def change
+    add_index :bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id],
+              unique: true, name: "index_bookmarks_uniqueness"
+    add_index :bookmarks, [:bookmarkable_type, :bookmarkable_id],
+              name: "index_bookmarks_on_target"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_17_101737) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_18_001222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "bookmarkable_type", null: false
+    t.bigint "bookmarkable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_bookmarkable"
+    t.index ["bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_target"
+    t.index ["user_id", "bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_uniqueness", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
 
   create_table "sentence_taggings", force: :cascade do |t|
     t.bigint "sentence_id", null: false
@@ -95,6 +107,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_17_101737) do
     t.index ["user_id"], name: "index_vocabulary_tags_on_user_id"
   end
 
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "sentence_taggings", "sentence_tags"
   add_foreign_key "sentence_taggings", "sentences"
   add_foreign_key "sentence_tags", "users"

--- a/lib/tasks/demo_import.rake
+++ b/lib/tasks/demo_import.rake
@@ -1,0 +1,74 @@
+require "yaml"
+
+namespace :demo do
+  def random_color
+    "#" + "%06x" % (rand * 0xffffff)
+  end
+
+  desc "Import demo vocabularies and sentences from YAML"
+  task import_yaml: :environment do
+    user = User.find_or_create_by!(email: "demo@example.com") do |u|
+      u.password = "password"
+      u.name = "Demo User"
+    end
+
+    vocab_file = Rails.root.join("db/demo_vocabularies.yml")
+    sent_file  = Rails.root.join("db/demo_sentences.yml")
+
+    if File.exist?(vocab_file)
+      data = YAML.load_file(vocab_file)
+      data["vocabularies"].each do |attrs|
+        v = user.vocabularies.create!(
+          word: attrs["word"],
+          reading: attrs["reading"],
+          part_of_speech: attrs["part_of_speech"],
+          meaning: attrs["meaning"],
+          example: attrs["example"]
+        )
+        if attrs["vocabulary_tags"]
+          attrs["vocabulary_tags"].each do |tag_name|
+            tag = VocabularyTag.find_or_initialize_by(name: tag_name, user: user)
+            tag.color ||= random_color
+            tag.save!
+            v.vocabulary_tags << tag unless v.vocabulary_tags.include?(tag)
+          end
+        end
+      end
+    end
+
+    if File.exist?(sent_file)
+      data = YAML.load_file(sent_file)
+      data["sentences"].each do |attrs|
+        s = user.sentences.create!(
+          body: attrs["body"],
+          sentence_category: attrs["sentence_category"]
+        )
+        if attrs["sentence_tags"]
+          attrs["sentence_tags"].each do |tag_name|
+            tag = SentenceTag.find_or_initialize_by(name: tag_name, user: user)
+            tag.color ||= random_color
+            tag.save!
+            s.sentence_tags << tag unless s.sentence_tags.include?(tag)
+          end
+        end
+      end
+    end
+
+    puts "✅ Demo data imported for #{user.email}"
+  end
+
+  desc "Clear demo data"
+  task clear_yaml: :environment do
+    user = User.find_by(email: "demo@example.com")
+    if user
+      user.vocabularies.destroy_all
+      user.sentences.destroy_all
+      puts "🗑 Demo data cleared."
+    else
+      puts "No demo user found."
+    end
+  end
+
+  desc "Reset demo data"
+  task reset_yaml: [:clear_yaml, :import_yaml]
+end

--- a/test/fixtures/add_indexes_to_bookmarks.yml
+++ b/test/fixtures/add_indexes_to_bookmarks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  bookmarkable: one
+  bookmarkable_type: Bookmarkable
+
+two:
+  user: two
+  bookmarkable: two
+  bookmarkable_type: Bookmarkable

--- a/test/models/add_indexes_to_bookmark_test.rb
+++ b/test/models/add_indexes_to_bookmark_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AddIndexesToBookmarkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookmarkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
お気に入り機能を作成。
お気に入りページにて、文章 / 語彙をタブ切り替えで表示できる。
語彙一覧 / 文章一覧ページにて作成日の上にお気に入りマークを実装。

また、お気に入り機能動作確認に伴う、テストデータを作成し、パッチ化。

Closes #54 
Closes #55 